### PR TITLE
Fix flaky test in kraken module

### DIFF
--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/KrakenUtilsTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/KrakenUtilsTest.java
@@ -13,6 +13,7 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
@@ -66,6 +67,7 @@ public class KrakenUtilsTest {
 
     UserTrades userTrades = KrakenAdapters.adaptTradesHistory(filteredKrakenTradeMap);
 
+    userTrades = new UserTrades(userTrades.getUserTrades(), TradeSortType.SortByID);
     UserTrade trade0 = userTrades.getUserTrades().get(0);
     assertThat(trade0).isInstanceOf(KrakenUserTrade.class);
     assertThat(trade0.getId()).isEqualTo("TY5BYV-WJUQF-XPYEYD-2");


### PR DESCRIPTION
This PR fixes the non deterministic behaviour of a test `org.knowm.xchange.kraken.KrakenUtilsTest#testAdaptTradeHistoryByCurrencyPair`. This happens as the test assumes the order of keys in a hashmap, which is not guaranteed. It has been detected using [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

### Reproduction of issue
1. `mvn install -pl xchange-kraken`
2. `mvn -pl xchange-kraken edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.knowm.xchange.kraken.KrakenUtilsTest#testAdaptTradeHistoryByCurrencyPair`

```
[INFO] Running org.knowm.xchange.kraken.KrakenUtilsTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.452 s <<< FAILURE! -- in org.knowm.xchange.kraken.KrakenUtilsTest
[ERROR] org.knowm.xchange.kraken.KrakenUtilsTest.testAdaptTradeHistoryByCurrencyPair -- Time elapsed: 0.431 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 

expected: "TY5BYV-WJUQF-XPYEYD-2"
 but was: "TY5BYV-WJUQF-XPYEYD-3"
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at org.knowm.xchange.kraken.KrakenUtilsTest.testAdaptTradeHistoryByCurrencyPair(KrakenUtilsTest.java:74)
```

### Root cause
The test class `org.knowm.xchange.kraken.KrakenUtilsTest` calls `adaptTradesHistory` which populates data into the list based on the order of values in the hashmap passed to it [Kraken Adapters population](https://github.com/knowm/XChange/blob/d56e61f2cf1368f917965a8c43f292a2a1b28ebc/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java#L299) before sorting it based on [timestamp](https://github.com/knowm/XChange/blob/d56e61f2cf1368f917965a8c43f292a2a1b28ebc/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java#L303). Two entries which pass the filter for this [test](https://github.com/knowm/XChange/blob/d56e61f2cf1368f917965a8c43f292a2a1b28ebc/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/trading/example-tradehistory-data.json) have the same timestamp and hence their order can be non deterministic. The test assumes the first element to be the one which appears first in the data file which may not be the case.

### Fix
The filtered list is sorted based on ID to ensure the result order is consistent. No source code has been touched.


### Verification of fix
- All tests in the class pass(`mvn -pl xchange-kraken test -Dtest=org.knowm.xchange.kraken.KrakenUtilsTest`)
- All tests in class pass when run with nondex(`mvn -pl xchange-kraken edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.knowm.xchange.kraken.KrakenUtilsTest`)